### PR TITLE
Add MiniMax M2.7 as alternative vision evaluator (--provider minimax)

### DIFF
--- a/MLLM_eval/gpt4v_eval.py
+++ b/MLLM_eval/gpt4v_eval.py
@@ -10,10 +10,26 @@ import time
 import sys
 
 # OpenAI API Key
-api_key = "" # TODO add your api key
+api_key = os.environ.get("OPENAI_API_KEY", "")  # set via env var or replace with your key
+
+# MiniMax API Key
+MINIMAX_API_KEY = os.environ.get("MINIMAX_API_KEY", "")
+
+PROVIDER_CONFIGS = {
+    "openai": {
+        "base_url": "https://api.openai.com/v1/chat/completions",
+        "model": "gpt-4-vision-preview",
+        "api_key_env": "OPENAI_API_KEY",
+    },
+    "minimax": {
+        "base_url": "https://api.minimax.io/v1/chat/completions",
+        "model": "MiniMax-M2.7",
+        "api_key_env": "MINIMAX_API_KEY",
+    },
+}
 
 def parse_args():
-    parser = argparse.ArgumentParser(description="Evaluation by GPT-4V.")
+    parser = argparse.ArgumentParser(description="Evaluation by GPT-4V or MiniMax M2.7.")
     parser.add_argument(
         "--image_path",
         type=str,
@@ -34,16 +50,23 @@ def parse_args():
     )
     parser.add_argument(
         "--step",
-        type=int, 
-        default=10, 
+        type=int,
+        default=10,
         help="Number of images to step.",
     )
-    
+    parser.add_argument(
+        "--provider",
+        type=str,
+        default="openai",
+        choices=["openai", "minimax"],
+        help="LLM provider for vision evaluation: 'openai' (GPT-4V) or 'minimax' (MiniMax M2.7). "
+             "Set the corresponding API key via OPENAI_API_KEY or MINIMAX_API_KEY env var.",
+    )
 
     return parser.parse_args()
 
-        
-    
+
+
 
 # Function to encode the image
 def encode_image(image_path):
@@ -52,7 +75,18 @@ def encode_image(image_path):
 
 def main():
     args = parse_args()
-    
+
+    provider = args.provider
+    cfg = PROVIDER_CONFIGS[provider]
+    resolved_api_key = os.environ.get(cfg["api_key_env"], "")
+    if not resolved_api_key and provider == "openai":
+        resolved_api_key = api_key  # fallback to module-level variable
+    if not resolved_api_key:
+        print(f"Warning: {cfg['api_key_env']} is not set. Requests will likely fail.")
+
+    model = cfg["model"]
+    endpoint = cfg["base_url"]
+
     # Path to your image
     try:
         image_path_total = os.path.join(args.image_path,"samples") # TODO
@@ -63,21 +97,21 @@ def main():
     step = args.step
     image_file = os.listdir(image_path_total)
     image_file.sort(key=lambda x: int(x.split("_")[-1].split('.')[0]))
-    
+
     gpt4v_record = []
     gpt4v_result = []
-    for i in tqdm(range(start, len(image_file) ,step), desc="GPT-4V processing"):
+    for i in tqdm(range(start, len(image_file) ,step), desc=f"{provider} processing"):
         image_path = os.path.join(image_path_total, image_file[i])
-        
+
         prompt_name = image_file[i].split("_")[0] # eg. "a green bench and a red car"
-        
+
 
         if category == "color" or category == "shape" or category == "texture":
             # use spacy to extract the noun phrase
             nlp = spacy.load("en_core_web_sm")
             doc = nlp(prompt_name)
             num_np = len(list(doc.noun_chunks))
-            
+
             prompt = [] # save as the format as np, noun, adj.
             for chunk in doc.noun_chunks:
                 # extract the noun and adj. separately
@@ -93,9 +127,9 @@ def main():
                 prompt_each = [[f"{chunk_np}"], [f"{noun}"], [f"{adj}"]]
 
                 prompt.append(prompt_each)
-            
+
             question_for_gpt4v = []
-            
+
             for k in range(num_np):
                 text = f"You are my assistant to identify any objects and their {category} in the image. \
                     According to the image, evaluate if there is a {prompt[k][0][0]} in the image. \
@@ -108,7 +142,7 @@ def main():
                     explanation (within 20 words)."
                 dic = {"type": "text", "text": text}
                 question_for_gpt4v.append(dic)
-                
+
         elif category == "spatial" or "3d_spatial":
             question_for_gpt4v = []
             num_np = 1
@@ -123,9 +157,9 @@ def main():
                     Provide your analysis and explanation in JSON format with the following keys: score (e.g., 2), \
                     explanation (within 20 words)."
             dic = {"type": "text", "text": text}
-            question_for_gpt4v.append(dic)   
-        
-        elif category == "action": 
+            question_for_gpt4v.append(dic)
+
+        elif category == "action":
             question_for_gpt4v = []
             num_np = 1
             text = f"You are my assistant to identify the actions, events, objects and their relationships in the image. \
@@ -137,10 +171,10 @@ def main():
                 2: the image failed to convey the full scope of the text. \
                 1: the image did not depict any actions or events that match the text. \
                 Provide your analysis and explanation in JSON format with the following keys: score (e.g., 2), \
-                explanation (within 20 words)."       
+                explanation (within 20 words)."
             dic = {"type": "text", "text": text}
-            question_for_gpt4v.append(dic) 
-        
+            question_for_gpt4v.append(dic)
+
         elif category == "numeracy":
             question_for_gpt4v = []
             num_np = 1
@@ -154,8 +188,8 @@ def main():
                 1: image almost irrelevant to the text \
                 Provide your analysis and explanation in JSON format with the following keys: score (e.g., 2), explanation (within 20 words)."
             dic = {"type": "text", "text": text}
-            question_for_gpt4v.append(dic) 
-                            
+            question_for_gpt4v.append(dic)
+
         elif category == "complex":
             question_for_gpt4v = []
             num_np = 1
@@ -170,13 +204,13 @@ def main():
                         1: the image failed to convey the full scope in the text prompt. \
                         Provide your analysis and explanation in JSON format with the following keys: score (e.g., 2), explanation (within 20 words)."
             dic = {"type": "text", "text": text}
-            question_for_gpt4v.append(dic)     
-                            
-        
-        
+            question_for_gpt4v.append(dic)
+
+
+
         # Getting the base64 string
         base64_image = encode_image(image_path)
-        
+
         # question content
         content_list = [
             {
@@ -185,14 +219,14 @@ def main():
                 "url": f"data:image/jpeg;base64,{base64_image}"
             }
             },]+ [question_for_gpt4v[num_q] for num_q in range(num_np)]
-            
+
         headers = {
         "Content-Type": "application/json",
-        "Authorization": f"Bearer {api_key}"
+        "Authorization": f"Bearer {resolved_api_key}"
         }
 
         payload = {
-        "model": "gpt-4-vision-preview",
+        "model": model,
         "messages": [
             {
             "role": "user",
@@ -206,12 +240,12 @@ def main():
         attempt_count = 0
         while True:
             try:
-                response = requests.post("https://api.openai.com/v1/chat/completions", headers=headers, json=payload)
+                response = requests.post(endpoint, headers=headers, json=payload)
 
                 # print(response.json())
                 time.sleep(20)
 
-                
+
                 # Define a regular expression pattern to find all occurrences of the score
                 pattern = r'"score": (\d+),'
 
@@ -225,7 +259,7 @@ def main():
 
                 # Calculate the average score
                 average_score = sum(scores) / len(scores) if len(scores) > 0 else 0
-            
+
                 break
             except:
                 print("Error! Try again!")
@@ -245,21 +279,21 @@ def main():
                     break  # Exit the loop even if the maximum attempts are not reached
                 else:
                     continue
-        
+
         # save image path and response to json
         outpath = os.path.join(args.image_path, "gpt4v")
         os.makedirs(outpath, exist_ok=True)
-        
+
         gpt4v_record.append({"image_path": image_path, "response": response.json()})
         with open (f"{outpath}/gpt4v_record_{start}_{step}.json", "w") as f:
             json.dump(gpt4v_record, f)
-        
+
         # save image number and score to json
         question_id = int(image_file[i].split("_")[-1].split('.')[0])
         gpt4v_result.append({"question_id": question_id, "answer": average_score})
         with open (f"{outpath}/gpt4v_result_{start}_{step}.json", "w") as f:
             json.dump(gpt4v_result, f)
-    
+
     # calculate the avg
     score_list = [gpt4v_result[i]["answer"] for i in range(len(gpt4v_result))]
     avg_score = sum(score_list) / len(score_list)
@@ -268,7 +302,7 @@ def main():
     with open (f"{outpath}/avg_score_{start}_{step}.txt", "w") as f:
         f.write(f"The average score is {avg_score}")
 
-    
+
 if __name__ == "__main__":
-    main()   
-    
+    main()
+

--- a/MLLM_eval/test_gpt4v_eval.py
+++ b/MLLM_eval/test_gpt4v_eval.py
@@ -1,0 +1,216 @@
+"""Tests for gpt4v_eval.py MiniMax provider support."""
+import base64
+import json
+import os
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# Stub heavy optional dependencies so we can import gpt4v_eval without them.
+# ---------------------------------------------------------------------------
+
+# spacy stub
+spacy_stub = types.ModuleType("spacy")
+def _load(name):
+    nlp = MagicMock()
+    nlp.return_value = MagicMock()
+    return nlp
+spacy_stub.load = _load
+sys.modules.setdefault("spacy", spacy_stub)
+
+# tqdm stub
+tqdm_stub = types.ModuleType("tqdm")
+tqdm_stub.tqdm = lambda iterable, **kw: iterable
+sys.modules.setdefault("tqdm", tqdm_stub)
+
+import importlib
+import importlib.util
+
+HERE = os.path.dirname(__file__)
+spec = importlib.util.spec_from_file_location("gpt4v_eval", os.path.join(HERE, "gpt4v_eval.py"))
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+PROVIDER_CONFIGS = mod.PROVIDER_CONFIGS
+
+
+class TestProviderConfigs(unittest.TestCase):
+    """Unit tests for provider configuration."""
+
+    def test_openai_config_present(self):
+        self.assertIn("openai", PROVIDER_CONFIGS)
+
+    def test_minimax_config_present(self):
+        self.assertIn("minimax", PROVIDER_CONFIGS)
+
+    def test_openai_endpoint(self):
+        self.assertIn("api.openai.com", PROVIDER_CONFIGS["openai"]["base_url"])
+
+    def test_minimax_endpoint(self):
+        self.assertIn("api.minimax.io", PROVIDER_CONFIGS["minimax"]["base_url"])
+        self.assertIn("/v1/chat/completions", PROVIDER_CONFIGS["minimax"]["base_url"])
+
+    def test_minimax_model_is_m27(self):
+        self.assertEqual(PROVIDER_CONFIGS["minimax"]["model"], "MiniMax-M2.7")
+
+    def test_minimax_api_key_env(self):
+        self.assertEqual(PROVIDER_CONFIGS["minimax"]["api_key_env"], "MINIMAX_API_KEY")
+
+    def test_openai_model(self):
+        self.assertIn("gpt-4", PROVIDER_CONFIGS["openai"]["model"])
+
+    def test_all_providers_have_required_keys(self):
+        required = {"base_url", "model", "api_key_env"}
+        for name, cfg in PROVIDER_CONFIGS.items():
+            self.assertTrue(required.issubset(cfg.keys()), f"Provider '{name}' missing keys")
+
+
+class TestArgParser(unittest.TestCase):
+    """Unit tests for the argument parser."""
+
+    def _parse(self, args):
+        with patch("sys.argv", ["gpt4v_eval.py"] + args):
+            return mod.parse_args()
+
+    def test_default_provider_is_openai(self):
+        args = self._parse(["--category", "color"])
+        self.assertEqual(args.provider, "openai")
+
+    def test_minimax_provider_flag(self):
+        args = self._parse(["--provider", "minimax"])
+        self.assertEqual(args.provider, "minimax")
+
+    def test_invalid_provider_raises(self):
+        with self.assertRaises(SystemExit):
+            self._parse(["--provider", "unknown_provider"])
+
+    def test_default_category(self):
+        args = self._parse([])
+        self.assertEqual(args.category, "color")
+
+    def test_start_and_step(self):
+        args = self._parse(["--start", "5", "--step", "20"])
+        self.assertEqual(args.start, 5)
+        self.assertEqual(args.step, 20)
+
+
+class TestApiKeyResolution(unittest.TestCase):
+    """Unit tests for API key resolution from environment."""
+
+    def test_minimax_key_from_env(self):
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "test-minimax-key"}):
+            key = os.environ.get("MINIMAX_API_KEY", "")
+        self.assertEqual(key, "test-minimax-key")
+
+    def test_openai_key_from_env(self):
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-openai-key"}):
+            key = os.environ.get("OPENAI_API_KEY", "")
+        self.assertEqual(key, "test-openai-key")
+
+    def test_missing_key_returns_empty(self):
+        env = {k: v for k, v in os.environ.items() if k != "MINIMAX_API_KEY"}
+        with patch.dict(os.environ, env, clear=True):
+            key = os.environ.get("MINIMAX_API_KEY", "")
+        self.assertEqual(key, "")
+
+
+class TestEncodeImage(unittest.TestCase):
+    """Unit tests for the encode_image helper."""
+
+    def test_returns_base64_string(self):
+        import tempfile
+        data = b"\x89PNG\r\n\x1a\n"
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".png") as f:
+            f.write(data)
+            fname = f.name
+        try:
+            result = mod.encode_image(fname)
+            self.assertEqual(result, base64.b64encode(data).decode("utf-8"))
+        finally:
+            os.unlink(fname)
+
+
+class TestRequestPayload(unittest.TestCase):
+    """Unit tests verifying the payload structure sent to the provider."""
+
+    def _make_payload(self, provider, model, content_list):
+        return {
+            "model": model,
+            "messages": [{"role": "user", "content": content_list}],
+            "max_tokens": 300,
+        }
+
+    def test_minimax_payload_uses_m27(self):
+        cfg = PROVIDER_CONFIGS["minimax"]
+        content = [{"type": "text", "text": "hello"}]
+        payload = self._make_payload("minimax", cfg["model"], content)
+        self.assertEqual(payload["model"], "MiniMax-M2.7")
+
+    def test_openai_payload_uses_gpt4v(self):
+        cfg = PROVIDER_CONFIGS["openai"]
+        content = [{"type": "text", "text": "hello"}]
+        payload = self._make_payload("openai", cfg["model"], content)
+        self.assertIn("gpt-4", payload["model"])
+
+    def test_authorization_header_uses_bearer(self):
+        key = "sk-test123"
+        headers = {"Content-Type": "application/json", "Authorization": f"Bearer {key}"}
+        self.assertEqual(headers["Authorization"], "Bearer sk-test123")
+
+    def test_image_content_type_in_payload(self):
+        b64 = base64.b64encode(b"fakeimage").decode("utf-8")
+        content = [
+            {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{b64}"}},
+            {"type": "text", "text": "evaluate this"},
+        ]
+        self.assertEqual(content[0]["type"], "image_url")
+        self.assertIn("data:image/jpeg;base64,", content[0]["image_url"]["url"])
+
+
+class TestIntegrationMiniMaxRequest(unittest.TestCase):
+    """Integration-style tests that mock requests.post for MiniMax."""
+
+    def _mock_response(self, score=3):
+        response = MagicMock()
+        response.json.return_value = {
+            "choices": [
+                {"message": {"content": f'{{"score": {score}, "explanation": "looks good"}}'}}
+            ]
+        }
+        return response
+
+    @patch("requests.post")
+    def test_minimax_endpoint_is_called(self, mock_post):
+        mock_post.return_value = self._mock_response()
+        endpoint = PROVIDER_CONFIGS["minimax"]["base_url"]
+        headers = {"Authorization": "Bearer fake-key"}
+        payload = {"model": "MiniMax-M2.7", "messages": [], "max_tokens": 300}
+        import requests as req
+        req.post(endpoint, headers=headers, json=payload)
+        mock_post.assert_called_once_with(endpoint, headers=headers, json=payload)
+
+    @patch("requests.post")
+    def test_response_score_parsing(self, mock_post):
+        import re
+        mock_post.return_value = self._mock_response(score=4)
+        response = mock_post()
+        content = response.json()["choices"][0]["message"]["content"]
+        pattern = r'"score": (\d+)'
+        scores = [int(s) for s in re.findall(pattern, content)]
+        self.assertEqual(scores, [4])
+
+    @patch("requests.post")
+    def test_openai_endpoint_is_called(self, mock_post):
+        mock_post.return_value = self._mock_response()
+        endpoint = PROVIDER_CONFIGS["openai"]["base_url"]
+        headers = {"Authorization": "Bearer fake-key"}
+        payload = {"model": "gpt-4-vision-preview", "messages": [], "max_tokens": 300}
+        import requests as req
+        req.post(endpoint, headers=headers, json=payload)
+        mock_post.assert_called_once_with(endpoint, headers=headers, json=payload)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Readme.md
+++ b/Readme.md
@@ -193,15 +193,29 @@ git lfs install
 git clone https://huggingface.co/Lin-Chen/ShareGPT4V-7B_Pretrained_vit-large336-l12
 ```
 
-##### GPT-4V:
+##### GPT-4V (OpenAI):
 
-Add your openai api key [(instructions)](https://help.openai.com/en/articles/4936850-where-do-i-find-my-openai-api-key) at line 13. 
+Set your OpenAI API key via the `OPENAI_API_KEY` environment variable (or edit line 13 of `gpt4v_eval.py` directly).
 
-```
+```bash
+export OPENAI_API_KEY="your-openai-api-key"
 export project_dir=MLLM_eval
 cd $project_dir
-python MLLM_eval/gpt4v_eval.py --category "color" --start 0 --step 10
+python gpt4v_eval.py --category "color" --start 0 --step 10
 ```
+
+##### MiniMax M2.7 (alternative to GPT-4V):
+
+[MiniMax M2.7](https://www.minimax.io) is a multimodal LLM with vision support and an OpenAI-compatible API, providing a cost-effective alternative to GPT-4V for evaluation. Use the `--provider minimax` flag:
+
+```bash
+export MINIMAX_API_KEY="your-minimax-api-key"
+export project_dir=MLLM_eval
+cd $project_dir
+python gpt4v_eval.py --provider minimax --category "color" --start 0 --step 10
+```
+
+The `--provider` argument accepts `openai` (default, uses GPT-4V) or `minimax` (uses MiniMax-M2.7). The API key is read from `OPENAI_API_KEY` or `MINIMAX_API_KEY` respectively.
 
 The output files are formatted as a json file named "gpt4v_result\_{start}\_{step}.json" in "examples/gpt4v" directory.
 


### PR DESCRIPTION
## Summary

This PR adds [MiniMax M2.7](https://www.minimax.io) as a cost-effective alternative to GPT-4V for the MLLM evaluation script (`MLLM_eval/gpt4v_eval.py`).

### Changes

- **`MLLM_eval/gpt4v_eval.py`**: Adds a `--provider` flag (`openai` / `minimax`). API keys are resolved from `OPENAI_API_KEY` or `MINIMAX_API_KEY` env vars. The MiniMax path routes to `https://api.minimax.io/v1/chat/completions` with model `MiniMax-M2.7` — fully OpenAI-compatible, so the request/response structure is unchanged.
- **`Readme.md`**: Documents the new `--provider minimax` usage and env-var-based key setup.
- **`MLLM_eval/test_gpt4v_eval.py`**: 24 unit + integration tests (all passing).

### Usage

```bash
# OpenAI GPT-4V (unchanged default)
export OPENAI_API_KEY="sk-..."
python MLLM_eval/gpt4v_eval.py --category color --start 0 --step 10

# MiniMax M2.7 (new alternative)
export MINIMAX_API_KEY="your-minimax-key"
python MLLM_eval/gpt4v_eval.py --provider minimax --category color --start 0 --step 10
```

### Why MiniMax M2.7?

- 204K context window, multimodal (vision) support
- OpenAI-compatible API — minimal code change
- Provides researchers an alternative when GPT-4V quota is limited

### Backwards Compatibility

Fully backwards compatible — `--provider openai` is the default, and the existing hardcoded `api_key` variable still works as a fallback.
