### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/MLLM_eval/gpt4v_eval.py
+++ b/MLLM_eval/gpt4v_eval.py
@@ -24,7 +24,7 @@ PROVIDER_CONFIGS = {
     "minimax": {
         "base_url": "https://api.minimax.io/v1/chat/completions",
         "model": "MiniMax-M3",
-        "models": ["MiniMax-M3", "MiniMax-M2.7"],
+        "models": ["MiniMax-M3", "MiniMax-M2.7", "MiniMax-M2.7-highspeed"],
         "api_key_env": "MINIMAX_API_KEY",
     },
 }
@@ -67,8 +67,8 @@ def parse_args():
         "--model",
         type=str,
         default=None,
-        help="Override the provider's default model. For 'minimax' choose MiniMax-M3 (default) "
-             "or MiniMax-M2.7. Defaults to the provider's configured model.",
+        help="Override the provider's default model. For 'minimax' choose MiniMax-M3 (default), "
+             "MiniMax-M2.7, or MiniMax-M2.7-highspeed. Defaults to the provider's configured model.",
     )
 
     return parser.parse_args()

--- a/MLLM_eval/gpt4v_eval.py
+++ b/MLLM_eval/gpt4v_eval.py
@@ -23,13 +23,14 @@ PROVIDER_CONFIGS = {
     },
     "minimax": {
         "base_url": "https://api.minimax.io/v1/chat/completions",
-        "model": "MiniMax-M2.7",
+        "model": "MiniMax-M3",
+        "models": ["MiniMax-M3", "MiniMax-M2.7"],
         "api_key_env": "MINIMAX_API_KEY",
     },
 }
 
 def parse_args():
-    parser = argparse.ArgumentParser(description="Evaluation by GPT-4V or MiniMax M2.7.")
+    parser = argparse.ArgumentParser(description="Evaluation by GPT-4V or MiniMax (M3 by default, M2.7 still available).")
     parser.add_argument(
         "--image_path",
         type=str,
@@ -59,8 +60,15 @@ def parse_args():
         type=str,
         default="openai",
         choices=["openai", "minimax"],
-        help="LLM provider for vision evaluation: 'openai' (GPT-4V) or 'minimax' (MiniMax M2.7). "
+        help="LLM provider for vision evaluation: 'openai' (GPT-4V) or 'minimax' (MiniMax, defaults to M3). "
              "Set the corresponding API key via OPENAI_API_KEY or MINIMAX_API_KEY env var.",
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default=None,
+        help="Override the provider's default model. For 'minimax' choose MiniMax-M3 (default) "
+             "or MiniMax-M2.7. Defaults to the provider's configured model.",
     )
 
     return parser.parse_args()
@@ -84,7 +92,7 @@ def main():
     if not resolved_api_key:
         print(f"Warning: {cfg['api_key_env']} is not set. Requests will likely fail.")
 
-    model = cfg["model"]
+    model = args.model or cfg["model"]
     endpoint = cfg["base_url"]
 
     # Path to your image

--- a/MLLM_eval/test_gpt4v_eval.py
+++ b/MLLM_eval/test_gpt4v_eval.py
@@ -62,6 +62,9 @@ class TestProviderConfigs(unittest.TestCase):
     def test_minimax_retains_m27(self):
         self.assertIn("MiniMax-M2.7", PROVIDER_CONFIGS["minimax"]["models"])
 
+    def test_minimax_retains_m27_highspeed(self):
+        self.assertIn("MiniMax-M2.7-highspeed", PROVIDER_CONFIGS["minimax"]["models"])
+
     def test_minimax_drops_deprecated_models(self):
         models = PROVIDER_CONFIGS["minimax"]["models"]
         for old in ("MiniMax-M2.5", "MiniMax-M2.1", "MiniMax-M2", "MiniMax-M1"):

--- a/MLLM_eval/test_gpt4v_eval.py
+++ b/MLLM_eval/test_gpt4v_eval.py
@@ -52,8 +52,20 @@ class TestProviderConfigs(unittest.TestCase):
         self.assertIn("api.minimax.io", PROVIDER_CONFIGS["minimax"]["base_url"])
         self.assertIn("/v1/chat/completions", PROVIDER_CONFIGS["minimax"]["base_url"])
 
-    def test_minimax_model_is_m27(self):
-        self.assertEqual(PROVIDER_CONFIGS["minimax"]["model"], "MiniMax-M2.7")
+    def test_minimax_default_model_is_m3(self):
+        self.assertEqual(PROVIDER_CONFIGS["minimax"]["model"], "MiniMax-M3")
+
+    def test_minimax_models_list_m3_first(self):
+        models = PROVIDER_CONFIGS["minimax"]["models"]
+        self.assertEqual(models[0], "MiniMax-M3")  # M3 is the new default / listed first
+
+    def test_minimax_retains_m27(self):
+        self.assertIn("MiniMax-M2.7", PROVIDER_CONFIGS["minimax"]["models"])
+
+    def test_minimax_drops_deprecated_models(self):
+        models = PROVIDER_CONFIGS["minimax"]["models"]
+        for old in ("MiniMax-M2.5", "MiniMax-M2.1", "MiniMax-M2", "MiniMax-M1"):
+            self.assertNotIn(old, models)
 
     def test_minimax_api_key_env(self):
         self.assertEqual(PROVIDER_CONFIGS["minimax"]["api_key_env"], "MINIMAX_API_KEY")
@@ -81,6 +93,14 @@ class TestArgParser(unittest.TestCase):
     def test_minimax_provider_flag(self):
         args = self._parse(["--provider", "minimax"])
         self.assertEqual(args.provider, "minimax")
+
+    def test_model_defaults_to_none(self):
+        args = self._parse(["--provider", "minimax"])
+        self.assertIsNone(args.model)
+
+    def test_model_override_flag(self):
+        args = self._parse(["--provider", "minimax", "--model", "MiniMax-M2.7"])
+        self.assertEqual(args.model, "MiniMax-M2.7")
 
     def test_invalid_provider_raises(self):
         with self.assertRaises(SystemExit):
@@ -142,11 +162,11 @@ class TestRequestPayload(unittest.TestCase):
             "max_tokens": 300,
         }
 
-    def test_minimax_payload_uses_m27(self):
+    def test_minimax_payload_uses_m3(self):
         cfg = PROVIDER_CONFIGS["minimax"]
         content = [{"type": "text", "text": "hello"}]
         payload = self._make_payload("minimax", cfg["model"], content)
-        self.assertEqual(payload["model"], "MiniMax-M2.7")
+        self.assertEqual(payload["model"], "MiniMax-M3")
 
     def test_openai_payload_uses_gpt4v(self):
         cfg = PROVIDER_CONFIGS["openai"]
@@ -186,7 +206,7 @@ class TestIntegrationMiniMaxRequest(unittest.TestCase):
         mock_post.return_value = self._mock_response()
         endpoint = PROVIDER_CONFIGS["minimax"]["base_url"]
         headers = {"Authorization": "Bearer fake-key"}
-        payload = {"model": "MiniMax-M2.7", "messages": [], "max_tokens": 300}
+        payload = {"model": "MiniMax-M3", "messages": [], "max_tokens": 300}
         import requests as req
         req.post(endpoint, headers=headers, json=payload)
         mock_post.assert_called_once_with(endpoint, headers=headers, json=payload)

--- a/Readme.md
+++ b/Readme.md
@@ -204,9 +204,9 @@ cd $project_dir
 python gpt4v_eval.py --category "color" --start 0 --step 10
 ```
 
-##### MiniMax M2.7 (alternative to GPT-4V):
+##### MiniMax M3 (alternative to GPT-4V):
 
-[MiniMax M2.7](https://www.minimax.io) is a multimodal LLM with vision support and an OpenAI-compatible API, providing a cost-effective alternative to GPT-4V for evaluation. Use the `--provider minimax` flag:
+[MiniMax M3](https://www.minimax.io) is a multimodal LLM with vision support and an OpenAI-compatible API, providing a cost-effective alternative to GPT-4V for evaluation. Use the `--provider minimax` flag:
 
 ```bash
 export MINIMAX_API_KEY="your-minimax-api-key"
@@ -215,7 +215,7 @@ cd $project_dir
 python gpt4v_eval.py --provider minimax --category "color" --start 0 --step 10
 ```
 
-The `--provider` argument accepts `openai` (default, uses GPT-4V) or `minimax` (uses MiniMax-M2.7). The API key is read from `OPENAI_API_KEY` or `MINIMAX_API_KEY` respectively.
+The `--provider` argument accepts `openai` (default, uses GPT-4V) or `minimax` (uses MiniMax-M3 by default). The API key is read from `OPENAI_API_KEY` or `MINIMAX_API_KEY` respectively. To use the previous MiniMax model instead, pass `--model MiniMax-M2.7`.
 
 The output files are formatted as a json file named "gpt4v_result\_{start}\_{step}.json" in "examples/gpt4v" directory.
 

--- a/Readme.md
+++ b/Readme.md
@@ -215,7 +215,7 @@ cd $project_dir
 python gpt4v_eval.py --provider minimax --category "color" --start 0 --step 10
 ```
 
-The `--provider` argument accepts `openai` (default, uses GPT-4V) or `minimax` (uses MiniMax-M3 by default). The API key is read from `OPENAI_API_KEY` or `MINIMAX_API_KEY` respectively. To use the previous MiniMax model instead, pass `--model MiniMax-M2.7`.
+The `--provider` argument accepts `openai` (default, uses GPT-4V) or `minimax` (uses MiniMax-M3 by default). The API key is read from `OPENAI_API_KEY` or `MINIMAX_API_KEY` respectively. To use a previous MiniMax model instead, pass `--model MiniMax-M2.7` or `--model MiniMax-M2.7-highspeed`.
 
 The output files are formatted as a json file named "gpt4v_result\_{start}\_{step}.json" in "examples/gpt4v" directory.
 


### PR DESCRIPTION
## Summary
Upgrade the MiniMax vision evaluator (`--provider minimax`) to use the latest **MiniMax-M3** model by default, while keeping MiniMax-M2.7 and MiniMax-M2.7-highspeed available as alternatives.

## Changes
- Set `MiniMax-M3` as the default model for the `minimax` provider in `PROVIDER_CONFIGS`
- Add a `models` list (`MiniMax-M3`, `MiniMax-M2.7`, `MiniMax-M2.7-highspeed`) with M3 listed first
- Add a `--model` flag so users can still select `MiniMax-M2.7` or `MiniMax-M2.7-highspeed` when needed
- Update unit tests and the README accordingly

## Why
MiniMax-M3 is the new flagship multimodal model (512K context window, up to 128K output, image input support), making it a better default than M2.7 for vision-based evaluation. M2.7 and M2.7-highspeed remain available via `--model MiniMax-M2.7` / `--model MiniMax-M2.7-highspeed` for reproducibility and lower-latency use cases.

## Testing
- `python -m unittest MLLM_eval.test_gpt4v_eval` -> 30 passed